### PR TITLE
feat: use v1 instead of v1beta1; add support for Workload Identity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 datastore-exporter
+Copyright (c) 2023 datastore-exporter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,6 @@ image:
 .PHONY: test
 test:
 ifeq ("$(wildcard $(shell which gocov))","")
-	go get github.com/axw/gocov/gocov
+	go install github.com/axw/gocov/gocov@latest
 endif
 	gocov test ${PKG_LIST} | gocov report

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To run locally a service account is required with the correct permissions to exp
 2. Download the key as JSON to your local machine
 3. Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of the account key e.g. `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
 
+Alternatively if you're using the Helm Chart you can make use of [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) and set the `gcloud.serviceAccount.workloadIdentity` field to your service account's name instead of having to create and manage a secret.
+
 ## Development
 
  - Go 1.11+

--- a/charts/datastore-exporter/Chart.yaml
+++ b/charts/datastore-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.1"
 description: A Helm chart to run the datastore exporter application as Kubernetes CronJob.
 name: datastore-exporter
-version: 0.1.0
+version: 0.2.0

--- a/charts/datastore-exporter/README.md
+++ b/charts/datastore-exporter/README.md
@@ -12,19 +12,20 @@ helm upgrade --install \
 
 ## Configuration
 
-| Parameter                          | Description                                 | Default                              |
-|------------------------------------|---------------------------------------------|--------------------------------------|
-| `image.repository`                 | Container image to deploy                   | `soon/datastore-exporter`            |
-| `image.pullPolicy`                 | Image pull policy                           | `IfNotPresent`                       |
-| `schedule`                         | Cron schedule to trigger job                | `0 0 * * *`                          |
-| `gcloud.project`                   | ID of the Google Cloud project              | ``                                   |
-| `gcloud.bucket`                    | GCS Bucket name you wish to export into     | ``                                   |
-| `gcloud.serviceAccount.secretName` | Secret housing the Google Cloud credentials | `datastore-exporter-service-account` |
-| `gcloud.serviceAccount.key`        | Key of the credentials file                 | `credentials.json`                   |
-| `imagePullSecrets`                 |                                             | `{}`                                 |
-| `nameOverride`                     |                                             | ``                                   |
-| `fullnameOverride`                 |                                             | ``                                   |
-| `resources`                        | Resource allocation (YAML)                  | `{}`                                 |
-| `nodeSelector`                     |                                             | `{}`                                 |
-| `tolerations`                      |                                             | `[]`                                 |
-| `affinity`                         |                                             | `{}`                                 |
+| Parameter                                | Description                                 | Default                              |
+|------------------------------------------|---------------------------------------------|--------------------------------------|
+| `image.repository`                       | Container image to deploy                   | `soon/datastore-exporter`            |
+| `image.pullPolicy`                       | Image pull policy                           | `IfNotPresent`                       |
+| `schedule`                               | Cron schedule to trigger job                | `0 0 * * *`                          |
+| `gcloud.project`                         | ID of the Google Cloud project              | ``                                   |
+| `gcloud.bucket`                          | GCS Bucket name you wish to export into     | ``                                   |
+| `gcloud.serviceAccount.secretName`       | Secret housing the Google Cloud credentials | `datastore-exporter-service-account` |
+| `gcloud.serviceAccount.key`              | Key of the credentials file                 | `credentials.json`                   |
+| `gcloud.serviceAccount.workloadIdentity` | Name of Workload Identity Service Account   | `` 									|
+| `imagePullSecrets`                       |                                             | `{}`                                 |
+| `nameOverride`                           |                                             | ``                                   |
+| `fullnameOverride`                       |                                             | ``                                   |
+| `resources`                              | Resource allocation (YAML)                  | `{}`                                 |
+| `nodeSelector`                           |                                             | `{}`                                 |
+| `tolerations`                            |                                             | `[]`                                 |
+| `affinity`                               |                                             | `{}`                                 |

--- a/charts/datastore-exporter/templates/cronjob.yaml
+++ b/charts/datastore-exporter/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "datastore-exporter.fullname" . }}
@@ -17,16 +17,21 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.gcloud.serviceAccount.workloadIdentity }}
+          serviceAccountName: {{ . | quote}}
+          {{- end }}
           volumes:
           - name: config
             configMap:
               name: {{ include "datastore-exporter.fullname" . }}-config
+          {{- if (not .Values.gcloud.serviceAccount.workloadIdentity) }}
           - name: gcloud-credentials
             secret:
               secretName: {{ .Values.gcloud.serviceAccount.secretName }}
               items:
                 - key: {{ .Values.gcloud.serviceAccount.key }}
                   path: {{ .Values.gcloud.serviceAccount.key }}
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
@@ -36,6 +41,7 @@ spec:
               readOnly: true
               mountPath: /etc/datastore-exporter/datastore-exporter.toml
               subPath: datastore-exporter.toml
+          {{- if (not .Values.gcloud.serviceAccount.workloadIdentity) }}
             - name: gcloud-credentials
               mountPath: /etc/datastore-exporter/credentials.json
               readOnly: true
@@ -43,6 +49,7 @@ spec:
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/datastore-exporter/credentials.json
+          {{- end }}
           restartPolicy: OnFailure
           {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/charts/datastore-exporter/values.yaml
+++ b/charts/datastore-exporter/values.yaml
@@ -14,6 +14,7 @@ gcloud:
   project: ""
   bucket: ""
   serviceAccount:
+    workloadIdentity: "" # If this is not empty, the below fields are unused.
     secretName: datastore-exporter-service-account
     key: credentials.json
 
@@ -21,7 +22,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
`batch/v1beta1` was deprecated in Kubernetes v1.21, and was removed in v1.25 (the latest stable GKE version is now v1.26 so we'll have problems soon).

I also took the liberty to add support for Workload Identity since the code doesn't seem to directly make use of the JWT in `credentials.json`.

This is semi-blocking SRD-926 due to the deprecated apiVersion

Also @andypwarren do we still use CircleCI? If not I could also add in Github Actions quick.